### PR TITLE
feat: improved feature to order page and add order detail page

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -8,6 +8,7 @@
     "pages/user/user",
     "pages/good_list/good_list",
     "pages/good_detail/good_detail",
+    "pages/order_detail/order_detail",
     "pages/collect/collect",
     "pages/order/order",
     "pages/searchResult/searchResult",

--- a/frontend/pages/order/order.js
+++ b/frontend/pages/order/order.js
@@ -2,6 +2,7 @@ import {request} from "../../request/index.js";
 //JS
 var app = getApp()
 let orderStatus = 1; //0"新订单，未支付;1"新订单，已支付";2, "已取消"；3"待评价"；4“已完成”
+const OrderStatysEnum = {0:"新订单，未支付", 21:"新订单，已支付", 2:"已取消", 3:"待评价", 4:"已完成"}
 Page({
   data: {
     // 顶部菜单切换
@@ -16,6 +17,9 @@ Page({
   Cates:[],
   // 页面加载会触发
   onLoad:function(options){
+    this.setData({
+      currentTab: parseInt(options.status)
+    })
     this.getCates();
   },
   //顶部tab切换
@@ -43,33 +47,34 @@ Page({
   },
 
   getMyOrderList() {
-    // let that = this;
+    let that = this;
     // let openid = app._checkOpenid();
-    // if (!openid) {
-    //   return;
-    // }
-    // //请求自己后台获取用户openid
-    // wx.request({
-    //   url: app.globalData.baseUrl + '/userOrder/listByStatus',
-    //   data: {
-    //     openid: openid,
-    //     orderStatus: orderStatus
-    //   },
-    //   success: function(res) {
-    //     console.log(res);
-    //     if (res && res.data && res.data.data && res.data.data.length > 0) {
-    //       let dataList = res.data.data;
-    //       console.log(dataList)
-    //       that.setData({
-    //         list: dataList
-    //       })
-    //     } else {
-    //       that.setData({
-    //         list: []
-    //       })
-    //     }
-    //   }
-    // })
+    let openid = 5;
+    if (!openid) {
+      return;
+    }
+    //请求自己后台获取用户openid
+    wx.request({
+      url: app.globalData.baseUrl + '/order/listByStatus?openid='+openid+'&orderStatus='+orderStatus,
+      success: function(res) {
+        try {
+          var dataList = res.data
+          that.setData({
+            list: dataList
+          })
+        } catch {
+          that.setData({
+            list: []
+          })
+        }
+      }
+    })
+  },
+
+  enterOrderDetail(event) {
+    wx.navigateTo({
+      url: '../order_detail/order_detail?order_id='+event.currentTarget.dataset.order,
+    })
   },
 
   getCates(){

--- a/frontend/pages/order/order.less
+++ b/frontend/pages/order/order.less
@@ -153,4 +153,176 @@ page{
 }
 
 
+.cart_content {
+  //background-color: rgb(245, 245, 245);
+  .cart_main {
+    height: 100%;
+    width: 95%;
+    background-color: white;
+    border-radius: 15px;
+    box-shadow: 8px 3px 3px rgb(231, 231, 231);
+    margin: auto;
+    .cart_item {
+      display: flex;
+      padding: 20rpx;
+      .cart_chk_wrap {
+        flex: 1;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        checkbox-group{
+          checkbox .wx-checkbox-input{
+            border-radius: 50%;
+            width: 42rpx; 
+            height: 42rpx; 
+            border: 1px solid rgb(156, 156, 156);
+          }
+          checkbox .wx-checkbox-input.wx-checkbox-input-checked{
+            border: 1rpx solid #FFA760;
+            background: #FFA760;
+          }
+          checkbox .wx-checkbox-input.wx-checkbox-input-checked::before{
+            border-radius: 50%;
+            width: 36rpx;
+            height: 36rpx;
+            line-height: 36rpx;
+            text-align: center;
+            font-size:28rpx;
+            color:#fff; 
+            background: transparent;
+            transform:translate(-50%, -50%) scale(1);
+            -webkit-transform:translate(-50%, -50%) scale(1);
+          }
+        }
+      }
+      .cart_img_wrap {
+        flex: 2;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        image {
+          width: 150rpx;
+          height: 150rpx;
+          border-radius: 3px;
+        }
+      }
+
+      .cart_info_wrap {
+        flex: 4;
+        display: block;
+        // flex-direction: column;
+        justify-content: space-around;
+        .good_name {
+          margin-top: 10rpx;
+          display: -webkit-box;
+          overflow: hidden;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp:2;
+          color: rgb(0, 0, 0);
+          font-size: 28rpx;
+        }
+
+        .good_price_wrap {
+          display: flex;
+          justify-content: space-between;
+          margin-top: 30rpx;
+          .good_price {
+            color: var(--themeColor);
+            font-size: 34rpx;
+            margin-top: 40rpx;
+            color: red;
+            display: flex;
+            .rmb{
+              display: inline-block;
+              align-self: flex-end;
+              font-size: 28rpx;
+              font-weight: 300;
+            }
+            .good_price_value{
+              margin-top: 6px;
+            }
+          }
+
+          .cart_num_tool {
+            display: flex;
+            margin-top: 40rpx;
+            .num_edit {
+              width: 50rpx;
+              height: 50rpx;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              border: 1rpx solid #f0f0f0;
+              font-size: 15px;
+            }
+            .minus{
+              border-radius: 5px 0px 0px 5px;
+            }
+            .plus{
+              border-radius: 0px 5px 5px 0px;
+            }
+
+            .good_num {
+              width: 70rpx;
+              height: 50rpx;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              font-size: 15px;
+              border-top: 1rpx solid #f0f0f0;
+              border-bottom: 1rpx solid #f0f0f0;
+            }
+          }
+        }
+      }
+    }
+    
+  }
+  .cart_main1{
+    .empty_info{
+      height: 100%;
+      // position: absolute;
+      // top: 40%;
+      // left: 50%;
+      // transform: translate(-50%, -50%);
+      .img_empty_cart{
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        .empty_cart{
+          width: 253px;
+          height: 222px;
+        }
+      }
+      .empty_message{
+        text-align: center;
+        font-size: 17px;
+        color: rgb(100, 100, 100);
+        font-weight: 300;
+        margin-top: 10px;
+      }
+      .good_home{
+        height: 45px;
+        margin-top: 30px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        .shopping_text{
+          height: 40px;
+          width: 50%;
+          background-color: #FFA760;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          color: #fff;
+          font-size: 17px;
+          font-weight: 450;
+          position: absolute;
+          border-radius: 30px;
+          text-align: center;
+        }
+      }
+    }
+  }
+}
  

--- a/frontend/pages/order/order.wxml
+++ b/frontend/pages/order/order.wxml
@@ -1,20 +1,41 @@
 <!--导航条-->
 <view class="navbar">
-  <lable wx:for="{{navbar}}" data-idx="{{index}}" class="item {{currentTab==index ? 'active' : ''}}" wx:key="unique" bindtap="navbarTap">
+  <label wx:for="{{navbar}}" data-idx="{{index}}" class="item {{currentTab==index ? 'active' : ''}}" wx:key="unique" bindtap="navbarTap">
     <text>{{item}}</text>
-  </lable>
+  </label>
 </view>
-<view wx:if="{{list.length>0}}">
- 
+<view class="cart_content">
+  <block wx:if="{{list.length>0}}">
+    <view class="cart_main">
+      <view class="cart_item"
+        wx:for="{{list}}"
+        wx:key="item"
+        bindtap="enterOrderDetail"
+        data-order="{{item.order_id}}"
+      >
+        <!-- 订单信息 -->
+        <view class="cart_info_wrap">
+          <view class="good_name">订单号：{{item.order_id}}</view>
+          <view class="good_price_wrap">
+            <view class="good_price">
+              <view class="rmb">￥</view>
+              <view class="good_price_value">订单价格：{{item.order_total_price}}</view>
+            </view>
+          </view>
+        </view>
+      </view>
+    </view>
+  </block>
+  <view wx:else class='no_item'>
+    <view class="empty_cart_container">
+      <image src="https://fnpphoto.cn/icon/svg/empty_cart.svg" class="empty_cart"></image>
+    </view>
+    <view class='no_item_text1'>你还没有相关的订单</view>
+    <view class='no_item_text2'>可以去看看有哪些想购买的</view>
+  </view>
 </view>
 <!-- 否则 -->
-<view wx:else class='no_item'>
-  <view class="empty_cart_container">
-    <image src="https://fnpphoto.cn/icon/svg/empty_cart.svg" class="empty_cart"></image>
-  </view>
-  <view class='no_item_text1'>你还没有相关的订单</view>
-  <view class='no_item_text2'>可以去看看有哪些想购买的</view>
-</view>
+
 
 <!-- 你还可以能喜欢 -->
 <view class="guess_like">

--- a/frontend/pages/order/order.wxss
+++ b/frontend/pages/order/order.wxss
@@ -141,3 +141,158 @@ page {
   width: 20px;
   margin-top: 7px;
 }
+.cart_content .cart_main {
+  height: 100%;
+  width: 95%;
+  background-color: white;
+  border-radius: 15px;
+  box-shadow: 8px 3px 3px #e7e7e7;
+  margin: auto;
+}
+.cart_content .cart_main .cart_item {
+  display: flex;
+  padding: 20rpx;
+}
+.cart_content .cart_main .cart_item .cart_chk_wrap {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.cart_content .cart_main .cart_item .cart_chk_wrap checkbox-group checkbox .wx-checkbox-input {
+  border-radius: 50%;
+  width: 42rpx;
+  height: 42rpx;
+  border: 1px solid #9c9c9c;
+}
+.cart_content .cart_main .cart_item .cart_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked {
+  border: 1rpx solid #FFA760;
+  background: #FFA760;
+}
+.cart_content .cart_main .cart_item .cart_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked::before {
+  border-radius: 50%;
+  width: 36rpx;
+  height: 36rpx;
+  line-height: 36rpx;
+  text-align: center;
+  font-size: 28rpx;
+  color: #fff;
+  background: transparent;
+  transform: translate(-50%, -50%) scale(1);
+  -webkit-transform: translate(-50%, -50%) scale(1);
+}
+.cart_content .cart_main .cart_item .cart_img_wrap {
+  flex: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.cart_content .cart_main .cart_item .cart_img_wrap image {
+  width: 150rpx;
+  height: 150rpx;
+  border-radius: 3px;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap {
+  flex: 4;
+  display: block;
+  justify-content: space-around;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_name {
+  margin-top: 10rpx;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: #000000;
+  font-size: 28rpx;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 30rpx;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap .good_price {
+  color: var(--themeColor);
+  font-size: 34rpx;
+  margin-top: 40rpx;
+  color: red;
+  display: flex;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap .good_price .rmb {
+  display: inline-block;
+  align-self: flex-end;
+  font-size: 28rpx;
+  font-weight: 300;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap .good_price .good_price_value {
+  margin-top: 6px;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap .cart_num_tool {
+  display: flex;
+  margin-top: 40rpx;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap .cart_num_tool .num_edit {
+  width: 50rpx;
+  height: 50rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1rpx solid #f0f0f0;
+  font-size: 15px;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap .cart_num_tool .minus {
+  border-radius: 5px 0px 0px 5px;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap .cart_num_tool .plus {
+  border-radius: 0px 5px 5px 0px;
+}
+.cart_content .cart_main .cart_item .cart_info_wrap .good_price_wrap .cart_num_tool .good_num {
+  width: 70rpx;
+  height: 50rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 15px;
+  border-top: 1rpx solid #f0f0f0;
+  border-bottom: 1rpx solid #f0f0f0;
+}
+.cart_content .cart_main1 .empty_info {
+  height: 100%;
+}
+.cart_content .cart_main1 .empty_info .img_empty_cart {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.cart_content .cart_main1 .empty_info .img_empty_cart .empty_cart {
+  width: 253px;
+  height: 222px;
+}
+.cart_content .cart_main1 .empty_info .empty_message {
+  text-align: center;
+  font-size: 17px;
+  color: #646464;
+  font-weight: 300;
+  margin-top: 10px;
+}
+.cart_content .cart_main1 .empty_info .good_home {
+  height: 45px;
+  margin-top: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.cart_content .cart_main1 .empty_info .good_home .shopping_text {
+  height: 40px;
+  width: 50%;
+  background-color: #FFA760;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-size: 17px;
+  font-weight: 450;
+  position: absolute;
+  border-radius: 30px;
+  text-align: center;
+}

--- a/frontend/pages/order_detail/order_detail.js
+++ b/frontend/pages/order_detail/order_detail.js
@@ -1,0 +1,62 @@
+// pages/order_detail/order_detail.js
+var app = getApp()
+Page({
+  /**
+   * 页面的初始数据
+   */
+  data: {
+      orderId: -1,
+      orderDetail: [],
+      totalPrice: 0
+  },
+
+  /**
+   * 生命周期函数--监听页面加载
+   */
+  onLoad: function (options) {
+    let that = this
+    this.setData({
+      orderId: options.order_id
+    })
+    wx.request({
+      url: app.globalData.baseUrl + '/order/order_detail_filter?filter='+options.order_id,
+      success: function(res) {
+        try {
+          var totalPrice = 0
+          for (const item of res.data.data) {
+            totalPrice += item.good_quantity * item.good_price
+          }
+          that.setData({
+            orderDetail: res.data.data,
+            totalPrice: totalPrice
+          })
+        } catch {
+          that.setData({
+            list: []
+          })
+        }
+      }
+    })
+  },
+
+  /**
+   * 页面相关事件处理函数--监听用户下拉动作
+   */
+  onPullDownRefresh: function () {
+
+  },
+
+  /**
+   * 页面上拉触底事件的处理函数
+   */
+  onReachBottom: function () {
+
+  },
+
+  /**
+   * 用户点击右上角分享
+   */
+  onShareAppMessage: function () {
+
+  }
+})

--- a/frontend/pages/order_detail/order_detail.json
+++ b/frontend/pages/order_detail/order_detail.json
@@ -1,0 +1,3 @@
+{
+  "usingComponents": {}
+}

--- a/frontend/pages/order_detail/order_detail.less
+++ b/frontend/pages/order_detail/order_detail.less
@@ -1,0 +1,318 @@
+
+page {
+  padding-bottom: 90rpx;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: #f6f6f6;
+}
+.revice_address_row .address_btn {
+  padding: 25rpx;
+}
+.revice_address_row .address_btn button {
+  width: 40%;
+}
+.revice_address_row .user_info_row {
+  display: flex;
+  padding: 20rpx;
+}
+.revice_address_row .user_info_row .user_info {
+  flex: 5;
+}
+.revice_address_row .user_info_row .user_phone {
+  flex: 3;
+  text-align: right;
+}
+.order_title {
+  padding: 20rpx;
+  font-size: 40rpx;
+  color: var(--themeColor);
+}
+.order_content .order_main {
+  height: 100%;
+  width: 95%;
+  background-color: white;
+  border-radius: 15px;
+  box-shadow: 8px 3px 3px #e7e7e7;
+  margin: auto;
+}
+.order_content .order_main .order_item {
+  display: flex;
+  padding: 20rpx;
+}
+.order_content .order_main .order_item .order_chk_wrap {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.order_content .order_main .order_item .order_chk_wrap checkbox-group checkbox .wx-checkbox-input {
+  border-radius: 50%;
+  width: 42rpx;
+  height: 42rpx;
+  border: 1px solid #9c9c9c;
+}
+.order_content .order_main .order_item .order_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked {
+  border: 1rpx solid #FFA760;
+  background: #FFA760;
+}
+.order_content .order_main .order_item .order_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked::before {
+  border-radius: 50%;
+  width: 36rpx;
+  height: 36rpx;
+  line-height: 36rpx;
+  text-align: center;
+  font-size: 28rpx;
+  color: #fff;
+  background: transparent;
+  transform: translate(-50%, -50%) scale(1);
+  -webkit-transform: translate(-50%, -50%) scale(1);
+}
+.order_content .order_main .order_item .order_img_wrap {
+  flex: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.order_content .order_main .order_item .order_img_wrap image {
+  width: 150rpx;
+  height: 150rpx;
+  border-radius: 3px;
+}
+.order_content .order_main .order_item .order_info_wrap {
+  flex: 4;
+  display: block;
+  justify-content: space-around;
+}
+.order_content .order_main .order_item .order_info_wrap .good_name {
+  margin-top: 10rpx;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: #000000;
+  font-size: 28rpx;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 30rpx;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .good_price {
+  color: var(--themeColor);
+  font-size: 34rpx;
+  margin-top: 40rpx;
+  color: red;
+  display: flex;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .good_price .rmb {
+  display: inline-block;
+  align-self: flex-end;
+  font-size: 28rpx;
+  font-weight: 300;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .good_price .good_price_value {
+  margin-top: 6px;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool {
+  display: flex;
+  margin-top: 40rpx;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool .num_edit {
+  width: 50rpx;
+  height: 50rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1rpx solid #f0f0f0;
+  font-size: 15px;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool .minus {
+  border-radius: 5px 0px 0px 5px;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool .plus {
+  border-radius: 0px 5px 5px 0px;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool .good_num {
+  width: 70rpx;
+  height: 50rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 15px;
+  border-top: 1rpx solid #f0f0f0;
+  border-bottom: 1rpx solid #f0f0f0;
+}
+.order_content .order_main1 .empty_info {
+  height: 100%;
+}
+.order_content .order_main1 .empty_info .img_empty_order {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.order_content .order_main1 .empty_info .img_empty_order .empty_order {
+  width: 253px;
+  height: 222px;
+}
+.order_content .order_main1 .empty_info .empty_message {
+  text-align: center;
+  font-size: 17px;
+  color: #646464;
+  font-weight: 300;
+  margin-top: 10px;
+}
+.order_content .order_main1 .empty_info .good_home {
+  height: 45px;
+  margin-top: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.order_content .order_main1 .empty_info .good_home .shopping_text {
+  height: 40px;
+  width: 50%;
+  background-color: #FFA760;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-size: 17px;
+  font-weight: 450;
+  position: absolute;
+  border-radius: 30px;
+  text-align: center;
+}
+.footer_tool {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100rpx;
+  background-color: #fff;
+  display: flex;
+  border-top: 1rpx solid #ccc;
+}
+.footer_tool .all_chk_wrap {
+  margin-left: 20rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.footer_tool .all_chk_wrap checkbox-group checkbox .wx-checkbox-input {
+  border-radius: 50%;
+  width: 42rpx;
+  height: 42rpx;
+  border: 1px solid #9c9c9c;
+}
+.footer_tool .all_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked {
+  border: 1rpx solid #FFA760;
+  background: #FFA760;
+}
+.footer_tool .all_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked::before {
+  border-radius: 50%;
+  width: 36rpx;
+  height: 36rpx;
+  line-height: 36rpx;
+  text-align: center;
+  font-size: 28rpx;
+  color: #fff;
+  background: transparent;
+  transform: translate(-50%, -50%) scale(1);
+  -webkit-transform: translate(-50%, -50%) scale(1);
+}
+.footer_tool .totol_order_box {
+  position: absolute;
+  right: 10px;
+  bottom: 0;
+  top: 0;
+  margin: auto;
+  margin-top: 5px;
+}
+.footer_tool .totol_order_box .totol_order {
+  display: flex;
+  justify-items: center;
+  align-items: center;
+  text-align: center;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap {
+  display: flex;
+  justify-items: center;
+  align-items: center;
+  text-align: center;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text {
+  display: flex;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text text {
+  color: #333333;
+  font-size: 12px;
+  margin-top: 4px;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text .totol_price_value {
+  color: red;
+  display: flex;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text .totol_price_value text {
+  font-size: 12px;
+  color: red;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text .totol_price_value .totol_price_value_1 {
+  font-size: 16px;
+  margin-left: 2px;
+  margin-top: 2px;
+}
+.footer_tool .totol_order_box .totol_order .pay_button {
+  background-color: tomato;
+  color: white;
+  font-size: 17px;
+  font-weight: 400;
+  border: none;
+  height: 80rpx;
+  width: 240rpx;
+  border-radius: 20px;
+  margin-left: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background-image: linear-gradient(to right, tomato 0%, #F45C43 51%, #e97254 100%);
+}
+@media screen and (max-width: 320px) {
+  .empty_info {
+    margin-top: 15%;
+    width: 320px;
+  }
+  .good_home {
+    width: 320px;
+  }
+}
+@media screen and (max-width: 414px) {
+  .empty_info {
+    margin-top: 25%;
+    width: 414px;
+  }
+  .good_home {
+    width: 414px;
+  }
+}
+@media screen and (max-width: 375px) {
+  .empty_info {
+    margin-top: 15%;
+    width: 375px;
+  }
+  .good_home {
+    width: 375px;
+  }
+}
+@media screen and (max-width: 320px) {
+  .empty_info {
+    margin-top: 10%;
+    width: 320px;
+  }
+  .empty_info .img_empty_order .empty_order {
+    height: 95px;
+    width: 125px;
+  }
+  .good_home {
+    width: 320px;
+  }
+}

--- a/frontend/pages/order_detail/order_detail.wxml
+++ b/frontend/pages/order_detail/order_detail.wxml
@@ -1,0 +1,36 @@
+
+<view class="order_title">订单详情</view>
+<!-- 购物车内容 -->
+<view class="order_content">
+  <view class="order_main">
+    <!-- Some Order Info -->
+    <view>
+      <p>
+        订单编号： {{orderId}}
+        订单总价： {{totalPrice}}
+      </p>
+    </view>
+    <view class="order_item"
+    wx:for="{{orderDetail}}"
+    wx:key="item"
+    >
+      <!-- 商品图片 -->
+      <navigator class="order_img_wrap">
+        <image src="{{item.good_image}}"></image>
+      </navigator>
+      <!-- 商品信息 -->
+      <view class="order_info_wrap">
+        <view class="good_name">商品名称：{{item.good_name}}</view>
+        <view class="good_name">商品单价：￥{{item.good_price}}</view>
+        <view class="good_name">订购数量：{{item.good_quantity}}</view>
+        <view class="good_price_wrap">
+          <view class="good_price">
+            <view class="rmb">商品总价：￥</view>
+            <view class="good_price_value">{{item.good_price*item.good_quantity}}</view>
+          </view>
+        </view>
+      </view>
+    </view>
+  </view>
+  <!-- </view> -->
+</view>

--- a/frontend/pages/order_detail/order_detail.wxss
+++ b/frontend/pages/order_detail/order_detail.wxss
@@ -1,0 +1,317 @@
+page {
+  padding-bottom: 90rpx;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: #f6f6f6;
+}
+.revice_address_row .address_btn {
+  padding: 25rpx;
+}
+.revice_address_row .address_btn button {
+  width: 40%;
+}
+.revice_address_row .user_info_row {
+  display: flex;
+  padding: 20rpx;
+}
+.revice_address_row .user_info_row .user_info {
+  flex: 5;
+}
+.revice_address_row .user_info_row .user_phone {
+  flex: 3;
+  text-align: right;
+}
+.order_title {
+  padding: 20rpx;
+  font-size: 40rpx;
+  color: var(--themeColor);
+}
+.order_content .order_main {
+  height: 100%;
+  width: 95%;
+  background-color: white;
+  border-radius: 15px;
+  box-shadow: 8px 3px 3px #e7e7e7;
+  margin: auto;
+}
+.order_content .order_main .order_item {
+  display: flex;
+  padding: 20rpx;
+}
+.order_content .order_main .order_item .order_chk_wrap {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.order_content .order_main .order_item .order_chk_wrap checkbox-group checkbox .wx-checkbox-input {
+  border-radius: 50%;
+  width: 42rpx;
+  height: 42rpx;
+  border: 1px solid #9c9c9c;
+}
+.order_content .order_main .order_item .order_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked {
+  border: 1rpx solid #FFA760;
+  background: #FFA760;
+}
+.order_content .order_main .order_item .order_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked::before {
+  border-radius: 50%;
+  width: 36rpx;
+  height: 36rpx;
+  line-height: 36rpx;
+  text-align: center;
+  font-size: 28rpx;
+  color: #fff;
+  background: transparent;
+  transform: translate(-50%, -50%) scale(1);
+  -webkit-transform: translate(-50%, -50%) scale(1);
+}
+.order_content .order_main .order_item .order_img_wrap {
+  flex: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.order_content .order_main .order_item .order_img_wrap image {
+  width: 150rpx;
+  height: 150rpx;
+  border-radius: 3px;
+}
+.order_content .order_main .order_item .order_info_wrap {
+  flex: 4;
+  display: block;
+  justify-content: space-around;
+}
+.order_content .order_main .order_item .order_info_wrap .good_name {
+  margin-top: 10rpx;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: #000000;
+  font-size: 28rpx;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 30rpx;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .good_price {
+  color: var(--themeColor);
+  font-size: 34rpx;
+  margin-top: 40rpx;
+  color: red;
+  display: flex;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .good_price .rmb {
+  display: inline-block;
+  align-self: flex-end;
+  font-size: 28rpx;
+  font-weight: 300;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .good_price .good_price_value {
+  margin-top: 6px;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool {
+  display: flex;
+  margin-top: 40rpx;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool .num_edit {
+  width: 50rpx;
+  height: 50rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1rpx solid #f0f0f0;
+  font-size: 15px;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool .minus {
+  border-radius: 5px 0px 0px 5px;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool .plus {
+  border-radius: 0px 5px 5px 0px;
+}
+.order_content .order_main .order_item .order_info_wrap .good_price_wrap .order_num_tool .good_num {
+  width: 70rpx;
+  height: 50rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 15px;
+  border-top: 1rpx solid #f0f0f0;
+  border-bottom: 1rpx solid #f0f0f0;
+}
+.order_content .order_main1 .empty_info {
+  height: 100%;
+}
+.order_content .order_main1 .empty_info .img_empty_order {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.order_content .order_main1 .empty_info .img_empty_order .empty_order {
+  width: 253px;
+  height: 222px;
+}
+.order_content .order_main1 .empty_info .empty_message {
+  text-align: center;
+  font-size: 17px;
+  color: #646464;
+  font-weight: 300;
+  margin-top: 10px;
+}
+.order_content .order_main1 .empty_info .good_home {
+  height: 45px;
+  margin-top: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.order_content .order_main1 .empty_info .good_home .shopping_text {
+  height: 40px;
+  width: 50%;
+  background-color: #FFA760;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-size: 17px;
+  font-weight: 450;
+  position: absolute;
+  border-radius: 30px;
+  text-align: center;
+}
+.footer_tool {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100rpx;
+  background-color: #fff;
+  display: flex;
+  border-top: 1rpx solid #ccc;
+}
+.footer_tool .all_chk_wrap {
+  margin-left: 20rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.footer_tool .all_chk_wrap checkbox-group checkbox .wx-checkbox-input {
+  border-radius: 50%;
+  width: 42rpx;
+  height: 42rpx;
+  border: 1px solid #9c9c9c;
+}
+.footer_tool .all_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked {
+  border: 1rpx solid #FFA760;
+  background: #FFA760;
+}
+.footer_tool .all_chk_wrap checkbox-group checkbox .wx-checkbox-input.wx-checkbox-input-checked::before {
+  border-radius: 50%;
+  width: 36rpx;
+  height: 36rpx;
+  line-height: 36rpx;
+  text-align: center;
+  font-size: 28rpx;
+  color: #fff;
+  background: transparent;
+  transform: translate(-50%, -50%) scale(1);
+  -webkit-transform: translate(-50%, -50%) scale(1);
+}
+.footer_tool .totol_order_box {
+  position: absolute;
+  right: 10px;
+  bottom: 0;
+  top: 0;
+  margin: auto;
+  margin-top: 5px;
+}
+.footer_tool .totol_order_box .totol_order {
+  display: flex;
+  justify-items: center;
+  align-items: center;
+  text-align: center;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap {
+  display: flex;
+  justify-items: center;
+  align-items: center;
+  text-align: center;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text {
+  display: flex;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text text {
+  color: #333333;
+  font-size: 12px;
+  margin-top: 4px;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text .totol_price_value {
+  color: red;
+  display: flex;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text .totol_price_value text {
+  font-size: 12px;
+  color: red;
+}
+.footer_tool .totol_order_box .totol_order .total_price_wrap .total_price_text .totol_price_value .totol_price_value_1 {
+  font-size: 16px;
+  margin-left: 2px;
+  margin-top: 2px;
+}
+.footer_tool .totol_order_box .totol_order .pay_button {
+  background-color: tomato;
+  color: white;
+  font-size: 17px;
+  font-weight: 400;
+  border: none;
+  height: 80rpx;
+  width: 240rpx;
+  border-radius: 20px;
+  margin-left: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background-image: linear-gradient(to right, tomato 0%, #F45C43 51%, #e97254 100%);
+}
+@media screen and (max-width: 320px) {
+  .empty_info {
+    margin-top: 15%;
+    width: 320px;
+  }
+  .good_home {
+    width: 320px;
+  }
+}
+@media screen and (max-width: 414px) {
+  .empty_info {
+    margin-top: 25%;
+    width: 414px;
+  }
+  .good_home {
+    width: 414px;
+  }
+}
+@media screen and (max-width: 375px) {
+  .empty_info {
+    margin-top: 15%;
+    width: 375px;
+  }
+  .good_home {
+    width: 375px;
+  }
+}
+@media screen and (max-width: 320px) {
+  .empty_info {
+    margin-top: 10%;
+    width: 320px;
+  }
+  .empty_info .img_empty_order .empty_order {
+    height: 95px;
+    width: 125px;
+  }
+  .good_home {
+    width: 320px;
+  }
+}

--- a/frontend/pages/personal/personal.js
+++ b/frontend/pages/personal/personal.js
@@ -16,9 +16,9 @@ Page({
     });
   },
 
-  goToMyOrder: function() {
+  goToMyOrder: function(event) {
     wx.navigateTo({
-      url: '../order/order',
+      url: '../order/order?status='+event.currentTarget.dataset.status,
     })
   },
 

--- a/frontend/pages/personal/personal.wxml
+++ b/frontend/pages/personal/personal.wxml
@@ -38,19 +38,19 @@
         <image src="https://fnpphoto.cn/icon/pre_pay.png" class="box1_row3_icon"></image>
         <view class="box1_row3_text">待付款</view>
       </view>
-      <view class="box1_row3_img_name">
+      <view class="box1_row3_img_name" bindtap="goToMyOrder" data-status="1">
         <image src="https://fnpphoto.cn/icon/wait_deliver.png" class="box1_row3_icon"></image>
         <view class="box1_row3_text">待发货</view>
       </view>
-      <view class="box1_row3_img_name">
+      <view class="box1_row3_img_name" bindtap="goToMyOrder" data-status="2">
         <image src="https://fnpphoto.cn/icon/pre_get_package.png" class="box1_row3_icon"></image>
         <view class="box1_row3_text">待收货</view>
       </view>
-      <view class="box1_row3_img_name">
+      <view class="box1_row3_img_name" bindtap="goToMyOrder" data-status="3">
         <image src="https://fnpphoto.cn/icon/pre_comment.png" class="box1_row3_icon"></image>
         <view class="box1_row3_text">待评价</view>
       </view>
-      <view class="box1_row3_img_name" bindtap="goToMyOrder">
+      <view class="box1_row3_img_name" bindtap="goToMyOrder" data-status="0">
         <image src="https://fnpphoto.cn/icon/my_order.png" class="box1_row3_icon"></image>
         <view class="box1_row3_text">所有订单</view>
       </view>


### PR DESCRIPTION
## Changes
- [X] Now when user click on different part of the navigator in "personal" page, it will direct to different order filters
- [X] Now order page will display some orders, with order status filter enabled
- [X] User can click on each order to see the detail on each order, the items, the individual/total price


**We still need to UI the pages...**